### PR TITLE
Add EOL array style comma rules

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -75,4 +75,15 @@
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+    <rule ref="Squiz.Arrays.ArrayDeclaration">
+        <include name="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast" />
+
+        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNoNewline" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned" />
+    </rule>
 </ruleset>

--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -77,6 +77,7 @@
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
     <rule ref="Squiz.Arrays.ArrayDeclaration">
         <include name="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast" />
+        <include name="Squiz.Arrays.ArrayDeclaration.CommaAfterLast" />
 
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNoNewline" />
         <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned" />

--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -78,7 +78,6 @@
     <rule ref="Squiz.Arrays.ArrayDeclaration">
         <include name="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast" />
         <include name="Squiz.Arrays.ArrayDeclaration.CommaAfterLast" />
-
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNoNewline" />
         <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned" />
         <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed" />

--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -85,6 +85,6 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed" />
         <exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned" />
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned" />
-        <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned" />
+        <include name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned" />
     </rule>
 </ruleset>


### PR DESCRIPTION
### What ?

Adding phpcs rule to control all array have comma at the end of all lines in multiline.
And no comma at the end in inline arrays.

### How to test

Use the ruleset from this branch and run phpcs you should get errors for all array with lines not ending with a comma or inline array with trailing comma.