### PR TITLE
Update style for read

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -23,6 +23,6 @@ interface ExampleDomainAccessInterface
     public function fetchOneBy(CriteriaInterface $criteria): ?ReadModel;
     
     // fetch multiple elements (a collection)
-    public function fetchBy(CriteriaInterface $criteria): \Traversable;
+    public function fetchAllBy(CriteriaInterface $criteria): \Traversable;
 }
 ``` 

--- a/docs/style.md
+++ b/docs/style.md
@@ -6,3 +6,23 @@ List of required and recommended styles for php apps and libraries.
 
 
 ## Recommendations
+
+### Recovering / fetching one or multiple elements
+
+As part of the `Application\Read` layer (but not only), when fetching one or multiple elements, we should strive to respect the following naming conventions (similar to what Doctrine does).
+
+```php
+namespace ShoppingFeed\ExampleDomain\Read
+
+interface ExampleDomainAccessInterface
+{
+    // fetch a specific element by ID
+    public function fetch(int $id): ?ReadModel
+
+    // fetch one element
+    public function fetchOneBy(CriteriaInterface $criteria): ?ReadModel;
+    
+    // fetch multiple elements (a collection)
+    public function fetchBy(CriteriaInterface $criteria): \Traversable;
+}
+``` 

--- a/docs/style.md
+++ b/docs/style.md
@@ -4,15 +4,13 @@ List of required and recommended styles for php apps and libraries.
 
 ## Requirements
 
-
-## Recommendations
-
 ### Recovering / fetching one or multiple elements
 
-As part of the `Application\Read` layer (but not only), when fetching one or multiple elements, we should strive to respect the following naming conventions (similar to what Doctrine does).
+As part of the `Application\Read` layer (but not only), when fetching one or multiple elements, 
+we should strive to respect the following naming conventions (similar to what Doctrine does).
 
 ```php
-namespace ShoppingFeed\ExampleDomain\Read
+namespace ShoppingFeed\ExampleDomain\Application\Read
 
 interface ExampleDomainAccessInterface
 {
@@ -20,9 +18,11 @@ interface ExampleDomainAccessInterface
     public function fetch(int $id): ?ReadModel
 
     // fetch one element
-    public function fetchOneBy(CriteriaInterface $criteria): ?ReadModel;
+    public function fetchBy(CriteriaInterface $criteria): ?ReadModel;
     
     // fetch multiple elements (a collection)
-    public function fetchAllBy(CriteriaInterface $criteria): \Traversable;
+    public function fetchAllBy(CriteriaInterface $criteria): \ShoppingFeed\Paginator\PaginatorAdapterInterface;
 }
 ``` 
+
+## Recommendations


### PR DESCRIPTION
As a result of this issue:
https://github.com/shoppingflux/coding-style-php/issues/14

I've opened this PR. 

We should probably also update this part of the DDD library doc: 
https://dev-tool.shopping-feed.com/lib.ddd/read/#read-repository

My only question is : do we have a naming convention regarding fetch / find ? I remember we had a Confluence page, but I cannot seem to find it. And searching through the dev-tool doc, I couldn't find anything either. I ask because : I feel like we're using fetch as a find. 

Find = go look for something, you might end up finding something or not
Fetch = go fetch me something, therefore you'll always have a result