### PR TITLE
Perl-style comments are not allowed

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -117,5 +117,11 @@
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
-
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
+        <properties>
+            <property name="forbiddenCommentPatterns" type="array">
+                <element value="^#"/>
+            </property>
+        </properties>
+    </rule>
 </ruleset>

--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -56,6 +56,7 @@
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent"/>
     <rule ref="MySource.PHP.GetRequestData"/>
+    <rule ref="PEAR.Commenting.InlineComment"/>
     <rule ref="PEAR.ControlStructures.ControlSignature"/>
     <rule ref="PSR1.Classes.ClassDeclaration"/>
     <rule ref="PSR1.Files.SideEffects"/>
@@ -117,11 +118,4 @@
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
-    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments">
-        <properties>
-            <property name="forbiddenCommentPatterns" type="array">
-                <element value="^#"/>
-            </property>
-        </properties>
-    </rule>
 </ruleset>


### PR DESCRIPTION
I'm trying to create a rule that prohibits certain comments (like Perl-style comments `#`). 

I've found this : 
https://github.com/slevomat/coding-standard#slevomatcodingstandardcommentingforbiddencomments-

And have therefore added the rule, but, with or without it, when testing a file that looks like this : 
```php
<?php

class Test {
    # comment
}
```

using the command `vendor/bin/phpcs`

there already seems to be a rule that is active, because I get this output : 
` ERROR | [x] Perl-style comments are not allowed. Use "// Comment." or "/* comment */" instead.`

But I don't know from which rule it comes from.

So this PR might not be necessary, but I'd like to know why. 