### PR TITLE
Add control structure spacing

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -60,6 +60,7 @@
     <rule ref="PEAR.ControlStructures.ControlSignature"/>
     <rule ref="PSR1.Classes.ClassDeclaration"/>
     <rule ref="PSR1.Files.SideEffects"/>
+    <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
     <rule ref="Squiz.PHP.Eval"/>
     <rule ref="Squiz.PHP.GlobalKeyword"/>
@@ -83,6 +84,7 @@
             <property name="spacingBeforeFirst" value="0"/>
         </properties>
     </rule>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
             <property name="spacing" value="1"/>


### PR DESCRIPTION
### Short description

I note that coding style check did not see some invalid structure.

Following codes are fine with the current rules :
```php
// Missing spaces
try {

}cach(\Exception $exception){

}

switch($var) {

}

// Breaking line not at the expected place
try {

}
catch (\Exception $exception) {

}

// Upper case statement
IF ($var) {
    // Do something
}
```

With the additional rules such code will no longer be accepted.