### PR TITLE
Add SpaceAfterNot rule

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -27,6 +27,7 @@
         </properties>
     </rule>
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot"/>
     <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
     <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>


### PR DESCRIPTION
### Description

Add missing rule on space after not.

```php
// Not valid code
if (!$isTrue) {
    // Do something
}

// Valid code
if (! $isTrue) {
    // Do something
}
```

Note that this issue can be automatically fixed by command line tool.

Please vote for this with :+1: or :-1: 