### PR TITLE
Add rules to remove useless comment and param type hint

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -120,6 +120,8 @@
     </rule>
 
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment.UselessDocComment"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
 </ruleset>


### PR DESCRIPTION
### Issue
See : https://github.com/shoppingflux/coding-style-php/issues/31

### Description
This rules remove useless function parameters comments. If all function parameters comments are useless, remove doc comment.
