### PR TITLE
Remove command time limit

### DIFF
--- a/src/Console/PHPCSCommand.php
+++ b/src/Console/PHPCSCommand.php
@@ -59,6 +59,8 @@ class PHPCSCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        set_time_limit(0);
+
         /** @var ProcessHelper $helper */
         $helper  = $this->getHelperSet()->get('process');
         $options = [


### PR DESCRIPTION
### Description
Remove following error :
```text
[Symfony\Component\Process\Exception\ProcessTimedOutException]                                                                                                           
  The process "'vendor/bin/phpcs' '--standard=/var/www/vendor/shoppingfeed/coding-style-php/phpcs/ruleset.xml' '--report=full' '--colors' '--parallel=1' '--ignore=*/soap  
  /*' 'backend' 'src' '-p'" exceeded the timeout of 60 seconds.
```

### Solution
- Set the process default timeout to 600 seconds
- Add an option to customize phpcs process timeout