### PR TITLE
Add preconisation for double parenthesis

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -183,4 +183,36 @@ interface ExampleDomainAccessInterface
 }
 ``` 
 
+### Parenthesis
+
+Never use double parenthesis like '((/* something */))'
+
+```php
+# Valid
+$firstCondition = true;
+$secondCondition = false;
+
+// Simple condition
+if ($firstCondition) {
+    // Do something
+}
+
+// Example with Coalescing operator
+trim((string) ($data[0]['address'] ?? ''));
+
+// Adding parenthesis is accepted if there is an operator between operand
+if (($firstCondition) && ($secondCondition)) {
+    // Do something
+}
+
+# Invalid
+// Simple condition
+if (($firstCondition)) {
+    // Do something
+}
+
+// Example with Coalescing operator
+trim(($data[0]['address'] ?? null));
+```
+
 ## Recommendations


### PR DESCRIPTION
### Linked issue
Issue: https://github.com/shoppingflux/coding-style-php/issues/17

### Description
Never use double parenthesis like '((/* something */))'