### PR TITLE
Remove OpeningFunctionBraceBsdAllman rule which is not compatible with PSR12

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -30,7 +30,6 @@
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
     <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
-    <rule ref="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
     <rule ref="Generic.NamingConventions.CamelCapsFunctionName">


### PR DESCRIPTION
### Description
OpeningFunctionBraceBsdAllman rule is not compatible with PSR12 regarding opening brace for multiline function declaration.

PSR-12 style :
```php
<?php

namespace Vendor\Package;

class ClassName
{
    public function aVeryLongMethodName(
        ClassTypeHint $arg1,
        &$arg2,
        array $arg3 = []
    ) {
        // method body
    }
}
```

OpeningFunctionBraceBsdAllman style :
```php
<?php

namespace Vendor\Package;

class ClassName
{
    public function aVeryLongMethodName(
        ClassTypeHint $arg1,
        &$arg2,
        array $arg3 = []
    )
    {
        // method body
    }
}
```