### PR TITLE
Add exclude option to command

### DIFF
--- a/src/Console/PHPCSCommand.php
+++ b/src/Console/PHPCSCommand.php
@@ -57,6 +57,12 @@ class PHPCSCommand extends Command
             'Determine if the code must be fixed before running CS checks'
         );
         $this->addOption(
+            'exclude',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'A comma separated list of sniff codes to exclude from checking'
+        );
+        $this->addOption(
             'timeout',
             't',
             InputOption::VALUE_REQUIRED,
@@ -81,6 +87,10 @@ class PHPCSCommand extends Command
         ];
 
         array_push($options, ...$input->getArgument('source'));
+
+        if ($input->getOption('exclude')) {
+            $options[] = '--exclude=' . $input->getOption('exclude');
+        }
 
         if ($input->getOption('progress')) {
             $options[] = '-p';


### PR DESCRIPTION
### Description
This PR add 'exclude' option to command. It will allow repositories to use sf coding style excluding some rules which will not be appropriate for repository usage.

The goal is to use this option in graphql-php repository to exclude 'Generic.CodeAnalysis.UselessOverridingMethod' rule. This rule is not appropriate in graphql project because override aims to add annotations which are required for graphql documentation.

### Test

Tested on graphql library

1. Test without exclude option, we get errors
![coding-style-exclude2](https://user-images.githubusercontent.com/10771538/147688471-d5ca2cf8-3a42-4e01-b09d-f7ef0456956d.png)

2. Test with exclude option, we no longer get error
![coding-style-exclude](https://user-images.githubusercontent.com/10771538/147688376-716d5f31-1867-4900-ba09-8bcc750bdc92.png)