### PR TITLE
Allow execution without source

### DIFF
--- a/src/Console/PHPCSCommand.php
+++ b/src/Console/PHPCSCommand.php
@@ -21,7 +21,7 @@ class PHPCSCommand extends Command
         );
         $this->addArgument(
             'source',
-            InputArgument::REQUIRED | InputArgument::IS_ARRAY,
+            InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
             'The source(s) folder(s) to analyse, multiples values allowed'
         );
         $this->addOption(
@@ -86,7 +86,9 @@ class PHPCSCommand extends Command
             '--ignore=' . $input->getOption('ignore'),
         ];
 
-        array_push($options, ...$input->getArgument('source'));
+        if ($source = $input->getArgument('source')) {
+            array_push($options, ...$source);
+        }
 
         if ($input->getOption('exclude')) {
             $options[] = '--exclude=' . $input->getOption('exclude');


### PR DESCRIPTION
When using a standard file (`--standard` flag), we are able to specify source paths to analyse, but the source argument override those paths.

The PR allow to only stick to sources defined in standard.