### PR TITLE
Add RequireOneLinePropertyDocComment rule

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -122,6 +122,7 @@
     </rule>
 
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
+    <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment.UselessDocComment"/>
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>


### PR DESCRIPTION
### Issue
#46

### Description
Force one line documentation comment for class properties