### PR TITLE
Add blank line before statement

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -124,6 +124,7 @@
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment.UselessDocComment"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,18 @@
 composer require shoppingfeed/coding-style-php
 ```
 
+### Contributing
+
+To connect to a php 8.0 container correctly configured
+
+- Create a container : `docker run --name coding-style-php -v $PWD:/var/www -d ghcr.io/shoppingflux/php:8.0.2-fpm`
+- Connect to container : `docker exec -it coding-style-php bash`
+
+Once connected to the container you can :
+
+- Update composer dependencies : `composer update`
+- Run test : `composer test`
+
 ### Documentation
 
 Documentation is driven by [mkdocs](https://www.mkdocs.org/) and uses [material theme](https://squidfunk.github.io/mkdocs-material/)


### PR DESCRIPTION
### Description
New rule : Add blank line before and after statement

This is already a rule in our CS : https://app.gitbook.com/o/1tB8pADISONsMIS9UdQr/s/fpptkFuihddMoYFuXhcx/docs/style#return-statement

See the result on API : https://github.com/shoppingflux/api/pull/1826