### PR TITLE
Do not handle case and default (conflict with other rule)

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -124,7 +124,17 @@
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment.UselessDocComment"/>
-    <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/>
+    <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing">
+        <properties>
+            <property name="controlStructures[]" value="if"/>
+            <property name="controlStructures[]" value="do"/>
+            <property name="controlStructures[]" value="while"/>
+            <property name="controlStructures[]" value="for"/>
+            <property name="controlStructures[]" value="foreach"/>
+            <property name="controlStructures[]" value="switch"/>
+            <property name="controlStructures[]" value="try"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>


### PR DESCRIPTION
### Description
There is an unresolvable conflict on switch case and switch default formatting. This PR exclude both from BlockControlStructureSpacing rule.