### PR TITLE
Add is_null in forbidden function

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -50,6 +50,7 @@
                 <element key="delete" value="unset"/>
                 <element key="print_r" value="return"/>
                 <element key="eval" value="none"/>
+                <element key="is_null" value="none"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
### Description
Add `is_null` in forbidden function, it should be replaced by `===` comparison. `is_null` is an old function from php 4 when `===` comparison didn't exist.

```php
$var = null;

// Forbidden
if (is_null($var) {

}

// Allowed
if (null === $var) {

}
```