### PR TITLE
Add new rules on Commenting and MultiLine

### DIFF
--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -57,6 +57,7 @@
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent"/>
     <rule ref="MySource.PHP.GetRequestData"/>
+    <rule ref="PEAR.Commenting.FunctionComment"/>
     <rule ref="PEAR.Commenting.InlineComment"/>
     <rule ref="PEAR.ControlStructures.ControlSignature"/>
     <rule ref="PEAR.NamingConventions.ValidClassName"/>

--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -57,7 +57,6 @@
     <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent"/>
     <rule ref="MySource.PHP.GetRequestData"/>
-    <rule ref="PEAR.Commenting.FunctionComment"/>
     <rule ref="PEAR.Commenting.InlineComment"/>
     <rule ref="PEAR.ControlStructures.ControlSignature"/>
     <rule ref="PEAR.NamingConventions.ValidClassName"/>

--- a/phpcs/ruleset.xml
+++ b/phpcs/ruleset.xml
@@ -124,8 +124,11 @@
 
     <config name="installed_paths" value="../../slevomat/coding-standard"/>
     <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+    <rule ref="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature"/>
+    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
     <rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment.UselessDocComment"/>
+    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing">
         <properties>
             <property name="controlStructures" type="array">
@@ -140,6 +143,7 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
+    <rule ref="SlevomatCodingStandard.Functions.RequireMultiLineCall"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>


### PR DESCRIPTION
## Description

Add following rules :
- SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature: Add new lines when method signature is longer than 120 chars
- SlevomatCodingStandard.Commenting.EmptyComment: Remove Empty Comment
- SlevomatCodingStandard.Commenting.UselessInheritDocComment: Remove useless InheritDoc comments
- SlevomatCodingStandard.Functions.RequireMultiLineCall: Add new lines when function call is longer than 120 chars

## Preview result on API
https://github.com/shoppingflux/api/pull/2639/files

> Note that RequireMultiLineCall rules have no effects here but it can be useful to save time by automatically fixing some errors when line exceeds 120 chars. It can be very usefull when massively applying a rector rule