### PR TITLE
Update the fix-only option behavior

### DIFF
--- a/src/Console/PHPCSCommand.php
+++ b/src/Console/PHPCSCommand.php
@@ -112,10 +112,11 @@ class PHPCSCommand extends Command
             $process = new Process($command);
             $process->setTimeout($timeout);
 
-            $process = $helper->run($output, $process, null, null, OutputInterface::VERBOSITY_NORMAL);
+            $helper->run($output, $process, null, null, OutputInterface::VERBOSITY_NORMAL);
 
+            // We always return success if fix-only to avoid to rerun phpcs after fixing
             if ($input->getOption('fix-only')) {
-                return $process->getExitCode();
+                return self::SUCCESS;
             }
         }
 

--- a/src/Console/PHPCSCommand.php
+++ b/src/Console/PHPCSCommand.php
@@ -114,7 +114,8 @@ class PHPCSCommand extends Command
 
             $helper->run($output, $process, null, null, OutputInterface::VERBOSITY_NORMAL);
 
-            // We always return success to avoid to rerun phpcs after fixing
+            // The fix-only option is used in automatic code fixer GitHub workflow.
+            // In that case, always return success so the next workflow step runs and any fixes can be committed.
             if ($input->getOption('fix-only')) {
                 return self::SUCCESS;
             }

--- a/src/Console/PHPCSCommand.php
+++ b/src/Console/PHPCSCommand.php
@@ -114,7 +114,7 @@ class PHPCSCommand extends Command
 
             $helper->run($output, $process, null, null, OutputInterface::VERBOSITY_NORMAL);
 
-            // We always return success if fix-only to avoid to rerun phpcs after fixing
+            // We always return success to avoid to rerun phpcs after fixing
             if ($input->getOption('fix-only')) {
                 return self::SUCCESS;
             }


### PR DESCRIPTION
With the --fix-only option, the command stop with error code. So we don't have any commit of change.

Here example of new behavior:
If CI can fix: https://github.com/shoppingflux/api/pull/3205
If CI can't fix: https://github.com/shoppingflux/api/pull/3206